### PR TITLE
Fix CORS error between client and server

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,6 +2,12 @@
 PORT=3000
 NODE_ENV=development
 
+# Required in production: Comma-separated list of allowed origins for CORS
+# Examples:
+#   For custom domain: ALLOWED_ORIGINS=https://set.jasonkatz.dev
+#   For multiple domains: ALLOWED_ORIGINS=https://set.jasonkatz.dev,https://api.set.jasonkatz.dev
+ALLOWED_ORIGINS=https://set.jasonkatz.dev
+
 # Required: Password for users to enter the game
 GAME_PASSWORD=your_secure_password_here
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,8 +28,19 @@ if (missingEnvVars.length > 0) {
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
 
+// Parse allowed origins from environment variable
+const allowedOrigins = isProduction
+  ? (process.env.ALLOWED_ORIGINS?.split(',').map(origin => origin.trim()) || [])
+  : ['http://localhost:5173', 'http://localhost:3000'];
+
+if (isProduction && allowedOrigins.length === 0) {
+  console.error('Missing required environment variable: ALLOWED_ORIGINS. ' +
+    'Please set it to a comma-separated list of allowed origins (e.g., https://set.jasonkatz.dev,https://api.set.jasonkatz.dev)');
+  process.exit(1);
+}
+
 app.use(cors({
-  origin: isProduction ? true : ['http://localhost:5173', 'http://localhost:3000'],
+  origin: allowedOrigins,
   credentials: true,
 }));
 


### PR DESCRIPTION
Replace the permissive `origin: true` in production with an explicit whitelist of allowed origins from the ALLOWED_ORIGINS environment variable. This fixes CORS issues when the client domain (set.jasonkatz.dev) makes requests to the server (set-server.vercel.app).

Changes:
- Add ALLOWED_ORIGINS environment variable (comma-separated list)
- Update CORS configuration to use explicit origin whitelist
- Add validation to require ALLOWED_ORIGINS in production
- Update .env.example with documentation and examples

This supports both the current setup and future custom domains like api.set.jasonkatz.dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch CORS to an env-driven whitelist (`ALLOWED_ORIGINS`) with production validation and update `.env.example`.
> 
> - **Backend (CORS)**:
>   - Parse `ALLOWED_ORIGINS` and set `cors({ origin: allowedOrigins, credentials: true })` in `server/src/index.ts`.
>   - In production, require `ALLOWED_ORIGINS` (comma-separated); exit with error if missing. In development, default to `['http://localhost:5173', 'http://localhost:3000']`.
> - **Config**:
>   - Document `ALLOWED_ORIGINS` with examples in `server/.env.example`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0c58e387c4e62225e30c8a861611fe7bc06a829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->