### PR TITLE
Remove Vercel protection bypass from query params

### DIFF
--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -18,14 +18,6 @@ interface AuthRequest extends Request {
   };
 }
 
-const handleVercelBypass = (req: Request, res: Response, next: NextFunction): void => {
-  const queryBypass = req.query.vercel_protection_bypass;
-  if (queryBypass && typeof queryBypass === 'string') {
-    req.headers['x-vercel-protection-bypass'] = queryBypass;
-  }
-  next();
-};
-
 const requireAuth = (req: AuthRequest, res: Response, next: NextFunction): void => {
   if (!req.session.userId) {
     res.status(401).json({ error: 'Not authenticated' });
@@ -78,7 +70,7 @@ router.get('/lobby', requireAuth, (req: AuthRequest, res: Response) => {
   res.json(data);
 });
 
-router.get('/lobby/stream', handleVercelBypass, requireAuth, (req: AuthRequest, res: Response) => {
+router.get('/lobby/stream', requireAuth, (req: AuthRequest, res: Response) => {
   const userId = req.session.userId!;
   sseManager.addLobbyClient(userId, res);
 
@@ -111,7 +103,7 @@ router.get('/games/:id', requireAuth, (req: AuthRequest, res: Response) => {
   res.json(gameData);
 });
 
-router.get('/games/:id/stream', handleVercelBypass, requireAuth, (req: AuthRequest, res: Response) => {
+router.get('/games/:id/stream', requireAuth, (req: AuthRequest, res: Response) => {
   const { id } = req.params;
   const userId = req.session.userId!;
 


### PR DESCRIPTION
Changed SSE implementation from EventSource (which doesn't support headers) to fetch with streaming, allowing the x-vercel-protection-bypass header to be sent directly instead of as a query parameter. Removed server-side middleware that was converting query params to headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces EventSource with header-capable fetch-streamed SSE on the client and removes server-side query-to-header Vercel bypass handling.
> 
> - **Client (`client/src/lib/socket.ts`)**:
>   - **SSE overhaul**: Replace `EventSource` with `fetch` streaming via new `streamSSE()` that parses SSE events and supports headers (incl. `x-vercel-protection-bypass`).
>   - **Lifecycle control**: Introduce `AbortController` for lobby/game streams (`startLobby`, `endLobby`, `gameUpdate`, `endGame`).
>   - Remove `buildSSEUrl` and `EventSource` usage; keep existing REST calls through `fetchAPI`.
> - **Server (`server/src/routes.ts`)**:
>   - Remove `handleVercelBypass` middleware and its usage from `/lobby/stream` and `/games/:id/stream` routes.
>   - SSE endpoints unchanged otherwise and still gated by `requireAuth`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19a569eae11a15068f59d552cfdee55ecae113bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->