### PR TITLE
Fix session cookie not being set on login

### DIFF
--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -53,9 +53,16 @@ router.post('/auth/login', (req: AuthRequest, res: Response) => {
   req.session.userId = userId;
   req.session.nickname = user.nickname;
 
-  console.log(`User ${user.nickname} (${userId}) logged in`);
+  req.session.save((err) => {
+    if (err) {
+      console.error('Session save error:', err);
+      res.status(500).json({ success: false, error: 'Failed to save session' });
+      return;
+    }
 
-  res.json({ success: true, user });
+    console.log(`User ${user.nickname} (${userId}) logged in`);
+    res.json({ success: true, user });
+  });
 });
 
 router.post('/auth/logout', requireAuth, (req: AuthRequest, res: Response) => {


### PR DESCRIPTION
## Summary

- Explicitly save session before sending login response to ensure Set-Cookie header is properly sent
- Resolves 401 errors on subsequent authenticated requests in production environment
- Add error handling for session save failures

## Test plan

- [ ] Deploy to production environment
- [ ] Log in and verify session cookie is set in browser
- [ ] Verify subsequent authenticated requests (e.g., /lobby, /games) succeed without 401 errors
- [ ] Verify session persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)